### PR TITLE
inout called wild when used as a storage class

### DIFF
--- a/src/dil/Enums.d
+++ b/src/dil/Enums.d
@@ -118,7 +118,7 @@ static:
     "shared",
     "gshared",
     "thread",
-    "wild",
+    "inout",
     "@disable",
     "@property",
     "@safe",


### PR DESCRIPTION
I think "inout" is a better name for it :).

With this commit the documentation seems to be generated very well, essentially equivalently to my patched version of D1 dil. Check it out: http://siegelord.github.com/Tango-D2/

There are some issues with the javascript... but I think that always was there, and I'll be investigating it on a smaller project.
